### PR TITLE
Enabled configuration of remote APIs by moving model name parameter from main.ts to config.ts

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -12,7 +12,10 @@ export const MAX_TOKENS = 500;
 // Add generation/sampling parameters here. Their effect depends on the API provider.
 // No attempt is made to normalize these parameters across different providers.
 // They are passed to the API endpoint unmodified.
+// Model name parameter is ignored by most OpenAI-compatible local API providers but sometimes required for remote API providers, 
+// For model name paramater, use full name e.g. "mistralai/Mixtral-8x22B-Instruct-v0.1" (Note, top_k value of 1 also sometimes required.)
 export const PARAMS = {
+    model: "gpt-3.5-turbo-instruct",
     temperature: 1.0,
     top_k: 0,
     top_p: 1.0,

--- a/src/main.ts
+++ b/src/main.ts
@@ -43,8 +43,6 @@ function scrollEmbedIntoView() {
 async function streamText(prompt: string, pane: Element): Promise<string> {
     const params: OpenAI.CompletionCreateParamsStreaming = {
         stream: true,
-        // This parameter is ignored by most OpenAI-compatible local API providers.
-        model: "gpt-3.5-turbo-instruct",
         prompt: prompt,
         max_tokens: MAX_TOKENS,
         // @ts-ignore: llama.cpp


### PR DESCRIPTION
Moved model name parameter from main.ts to config.ts. 

This parameter is rarely needed for local APIs but needs to be configured for remote APIs that support completions, added note about format of model name and top-k value change sometimes required.

Tested successfully using APIs from together.ai and anyscale.com, failed test using groq.com API because completions aren't supported only chat/completions.